### PR TITLE
Allow file upload for compiler

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       <div id="line-numbers"></div>
       <textarea id="code-input" placeholder="Cole seu código C aqui…"></textarea>
     </div>
+    <input type="file" id="file-input" accept=".txt,.opus" />
     <button id="btn-show">Exibir Código</button>
     <button id="btn-run">Executar Código C</button>
   </div>
@@ -52,6 +53,7 @@
     const codeInput   = document.getElementById('code-input');
     const codeDisplay = document.querySelector('#code-display-content code');
     const lineNumbers = document.getElementById('line-numbers');
+    const fileInput   = document.getElementById('file-input');
     const btnShow     = document.getElementById('btn-show');
     const btnRun      = document.getElementById('btn-run');
     const consoleOut  = document.getElementById('console-output');
@@ -66,6 +68,18 @@
     codeInput.addEventListener('scroll', () => {
       lineNumbers.scrollTop = codeInput.scrollTop;
     });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          codeInput.value = e.target.result;
+          updateLineNumbers();
+          displayCodeAndHighlight();
+        };
+        reader.readAsText(file);
+      }
+    });
     document.addEventListener('DOMContentLoaded', () => {
       updateLineNumbers();
       displayCodeAndHighlight();
@@ -79,10 +93,7 @@
     }
     btnShow.addEventListener('click', displayCodeAndHighlight);
 
-    function runCProgram() {
-      consoleOut.textContent = '';
-      treeOut.textContent = '';
-      const src = codeInput.value + '\n';
+    function sendCode(src) {
       fetch('/run', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -101,6 +112,22 @@
       .catch(err => {
         consoleOut.textContent += '[Erro] ' + err.message + '\n';
       });
+    }
+
+    function runCProgram() {
+      consoleOut.textContent = '';
+      treeOut.textContent = '';
+      const file = fileInput.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          sendCode(reader.result + '\n');
+        };
+        reader.readAsText(file);
+      } else {
+        const src = codeInput.value + '\n';
+        sendCode(src);
+      }
     }
     btnRun.addEventListener('click', runCProgram);
   </script>


### PR DESCRIPTION
## Summary
- allow uploading `.txt` and `.opus` files in the web UI
- load file contents into the editor area
- send uploaded file contents or textarea contents to the backend

## Testing
- `node server.js` *(started and logged "Server rodando" then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6862dfb700d88328990ad56cb48fef3a