### PR TITLE
Fix run endpoint

### DIFF
--- a/api/run.js
+++ b/api/run.js
@@ -1,8 +1,8 @@
 // api/run.js
-import { spawn } from 'child_process';
-import path from 'path';
+const { spawn } = require('child_process');
+const path = require('path');
 
-export default function handler(req, res) {
+module.exports = function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ stderr: 'Method Not Allowed' });
   }
@@ -12,7 +12,10 @@ export default function handler(req, res) {
   let stderr = '';
 
   // executa o seu parser/opus
-  const child = spawn('node', [path.join(process.cwd(), 'opus.js')]);
+  // opus.js fica na raiz do projeto
+  // em serverless bundles da Vercel o path relativo precisa subir um nível
+  const opusPath = path.join(__dirname, '..', 'opus.js');
+  const child = spawn('node', [opusPath]);
 
   child.stdout.on('data', data => { stdout += data.toString(); });
   child.stderr.on('data', data => { stderr += data.toString(); });

--- a/index.html
+++ b/index.html
@@ -280,7 +280,13 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code: src })
       })
-      .then(r => r.json())
+      .then(async r => {
+        if (!r.ok) {
+          const text = await r.text();
+          throw new Error(`Status ${r.status}: ${text}`);
+        }
+        return r.json();
+      })
       .then(res => {
         if (res.stderr) consoleOut.textContent += res.stderr;
         if (res.stdout) treeOut.textContent += res.stdout;

--- a/index.html
+++ b/index.html
@@ -231,6 +231,7 @@
     const treeOut      = document.getElementById('tree-output');
     const notification = document.getElementById('notification');
     const highlighted  = document.getElementById('highlighted-code');
+    const RUN_ENDPOINT = '/api/run';
 
     function updateLineNumbers() {
       const count = codeInput.value.split('\n').length;
@@ -274,7 +275,7 @@
     });
 
     function sendCode(src) {
-      fetch('/run', {
+      fetch(RUN_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code: src })

--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ function runCode(code, callback) {
 }
 
 http.createServer((req, res) => {
-  if (req.method === 'POST' && req.url === '/run') {
+  if (req.method === 'POST' && (req.url === '/run' || req.url === '/api/run')) {
     let body = '';
     req.on('data', chunk => body += chunk);
     req.on('end', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/run.js": {
+      "includeFiles": "opus.js"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- point the front-end AJAX to `/api/run`
- accept `/api/run` on the dev server
- fix `api/run.js` to use CommonJS
- bundle `opus.js` in the Vercel function so spawn works
- fix path to `opus.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862e96d1c0c83289e331403d00905d3